### PR TITLE
Fix: num_labels from config

### DIFF
--- a/training/cramming/architectures/crammed_bert.py
+++ b/training/cramming/architectures/crammed_bert.py
@@ -261,7 +261,7 @@ class ScriptableLMForSequenceClassification(PreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.cfg = OmegaConf.create(config.arch)
-        self.num_labels = self.cfg.num_labels
+        self.num_labels = getattr(config, "num_labels", self.cfg.num_labels)
 
         self.encoder = ScriptableLM(config)
         self.pooler = PoolingComponent(self.cfg.classification_head, self.cfg.hidden_size)
@@ -320,7 +320,7 @@ class ScriptableLMForSCRIPTTraining(PreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.cfg = OmegaConf.create(config.arch)
-        self.num_labels = self.cfg.num_labels
+        self.num_labels = getattr(config, "num_labels", self.cfg.num_labels)
 
         self.encoder = ScriptableLM(config)
         self.prediction_head = PredictionHeadComponent(self.cfg)


### PR DESCRIPTION
In huggingface `AutoConfig.from_pretrained`, `num_labels` will be written as an attribute of `config` instead `config.arch`. I don't know why this repo loads `num_labels` from `config.arch`, which is `None` when the script runs for sequence classification task training. To make the codes available for [huggingface training scripts](https://github.com/huggingface/transformers/tree/main/examples/pytorch), I made a fix to the code reading `num_labels` from the config.